### PR TITLE
Adding addition instruction on executing the Chk-WAN via wan-event

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ e.g. Every 5 minutes
     fi
     EOF
 
+e.g. Every 3 minutes with arguments (report status, no wait and fails=1)
+
+    cat > /jffs/scripts/wan-event << EOF;chmod +x /jffs/scripts/wan-event
+    #!/bin/sh
+
+    if [ "\$2" == "connected" ];then
+       # Check WAN connectivity every 3 minutes
+       cru a WAN_Check "*/3 * * * * /jffs/scripts/ChkWAN.sh wan status nowait fails=1" &
+    fi
+    EOF
+
 Check desired cru (cron) schedule has been created
 
     cru l


### PR DESCRIPTION
I added a piece of wan-event code in the example section, mentioning how to use cru (cron) to schedule WAN connectivity check for every 3 minutes with arguments. 

It might be useful for the neophyte to use this program. Thanks.
